### PR TITLE
Add Measured Response trash cost

### DIFF
--- a/sets/elevation.js
+++ b/sets/elevation.js
@@ -6935,7 +6935,7 @@ cardSet[35074] = {
 
 //Measured Response
 //Weyland Operation: Black Ops
-//Cost: 5, Influence: 4
+//Cost: 5, Trash: 3, Influence: 4
 //Play only if the threat level is 4 or greater, and only if the Runner made a successful run during their last turn.
 //Do 4 meat damage unless the Runner pays 8 credits.
 cardSet[35078] = {
@@ -6945,6 +6945,7 @@ cardSet[35078] = {
   faction: "Weyland Consortium",
   influence: 4,
   cardType: "operation",
+  trashCost: 3,
   subTypes: ["Black Ops"],
   playCost: 5,
   


### PR DESCRIPTION
Added a trash cost to Measured Response and updated the comment. It looks like it's as simple as this small change based on phases.runAccessingCard in phases.js, but please note I made this change directly in GitHub and this has *not* been tested on my machine.

Here's the debug log from a game today where I noticed the bug (log recorded at the moment the card was accessed but could not be trashed):
[chiriboga-log-2026-02-01T03_31_52.650Z.txt](https://github.com/user-attachments/files/24988879/chiriboga-log-2026-02-01T03_31_52.650Z.txt)
