### PR TITLE
Prevent Bling from triggering when corp installs cards

### DIFF
--- a/sets/elevation.js
+++ b/sets/elevation.js
@@ -1569,6 +1569,8 @@ cardSet[35006] = {
     Enumerate: function(card) {
       //Don't trigger for Bling itself
       if (card === this) return [];
+	  //Don't trigger for installed corp cards
+	  if (card.player === corp) return [];
       //Only trigger if install cost was 0
       if (intended.installCostPaid !== 0) return [];
       //Must have cards in stack


### PR DESCRIPTION
Fixes an issue where Bling would allow the runner to host cards when the corp installed cards (during either players turn).